### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -222,8 +222,8 @@ function contrasting_gray_color(hc) {
 // and for reflecting the user's input back to them in messages.
 function escapeHTML(unsafeString) {
   return unsafeString
-     .replaceAll('→', '&#8594;')
      .replaceAll('&', '&amp;')
+     .replaceAll('→', '&#8594;')
      .replaceAll('<', '&lt;')
      .replaceAll('>', '&gt;')
      .replaceAll('"', '&quot;')


### PR DESCRIPTION
Potential fix for [https://github.com/Ahmed13201/sankeymatic/security/code-scanning/1](https://github.com/Ahmed13201/sankeymatic/security/code-scanning/1)

To fix the issue, the order of replacements in the `escapeHTML` function should be adjusted so that the ampersand (`&`) is escaped first. This ensures that any pre-existing escaped characters are handled correctly and prevents double-escaping. The fix involves reordering the `.replaceAll('&', '&amp;')` call to be the first replacement in the chain.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
