### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/build/sankeymatic.js
+++ b/build/sankeymatic.js
@@ -2957,9 +2957,17 @@ Total Outputs: <strong>${withUnits(grandTotal[OUT])}</strong>`;
       maxNodeVal / (tallestNodeHeight || Number.MIN_VALUE),
       { ...numberStyle, decimalPlaces: 4 }
     );
-  el('scale_figures').innerHTML
-    = `<strong>${unitsPerPixel}</strong> per pixel
-(${withUnits(maxNodeVal)}/${formattedPixelCount}px)`;
+  const scaleFiguresEl = el('scale_figures');
+  // Build the contents safely to avoid interpreting any dynamic text as HTML:
+  scaleFiguresEl.textContent = '';
+  const strongEl = document.createElement('strong');
+  strongEl.textContent = unitsPerPixel;
+  scaleFiguresEl.appendChild(strongEl);
+  scaleFiguresEl.appendChild(
+    document.createTextNode(
+      ` per pixel (${withUnits(maxNodeVal)}/${formattedPixelCount}px)`
+    )
+  );
 
   updateResetNodesUI();
 


### PR DESCRIPTION
Potential fix for [https://github.com/Ahmed13201/sankeymatic/security/code-scanning/5](https://github.com/Ahmed13201/sankeymatic/security/code-scanning/5)

General approach: avoid reinterpreting any data that ultimately comes from DOM text as HTML. In this case, we can replace the `innerHTML` assignment on `scale_figures` with DOM manipulation using `textContent` and `innerHTML` only for static, trusted markup. This ensures that even if future changes allow more user-controlled content into `unitsPerPixel` or `formattedPixelCount`, it cannot break out of the intended text context.

Best concrete fix: instead of writing the whole string via `innerHTML`, we build the contents of `#scale_figures` programmatically:

1. Clear its existing content.
2. Create a `<strong>` element, set its `textContent` to `unitsPerPixel`, and append it.
3. Append a text node `" per pixel ("`.
4. Create another `<span>` or text node containing the safe `withUnits(maxNodeVal)` and `formattedPixelCount` text (these values are numeric/derived and safe in text context), and append it, along with `"px)"`.

This keeps the `<strong>` markup but ensures all dynamic values are used as text, not HTML. Only lines 2960–2962 in `build/sankeymatic.js` need to change; no new imports or helper functions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
